### PR TITLE
Improvements

### DIFF
--- a/autoload/wintabs.vim
+++ b/autoload/wintabs.vim
@@ -67,6 +67,9 @@ function! wintabs#close()
     if !getbufvar(buffer, '&modified')
       call filter(w:wintabs_buflist, 'v:val != '.buffer)
     endif
+    if (g:wintabs_wipeout_buffer_onclose)
+        execute "bwipeout " . buffer
+    endif
   endif
 endfunction
 
@@ -202,6 +205,17 @@ function! wintabs#go(n)
   call s:switch_tab(n, 0)
 endfunction
 
+" move to the previous tab
+function! wintabs#previous()
+	let buffer = bufnr('#')
+	let pos = index(w:wintabs_buflist, buffer)
+	if pos == -1
+		return
+	endif
+	let pos = pos + 1
+	call wintabs#go(pos)
+endfunction
+
 " move the current tab by n tabs
 function! wintabs#move(n)
   call wintabs#refresh_buflist(0)
@@ -317,6 +331,7 @@ function! s:buflisted(buffer)
   let filetype = getbufvar(a:buffer, '&filetype', '')
   let ignored = index(g:wintabs_ignored_filetypes, filetype) != -1
   let empty = bufname(a:buffer) == '' && !getbufvar(a:buffer, '&modified')
+  ""echomsg string(a:buffer) . ": " . string(filetype) . " "  . string(ignored) . " " . string(empty)
   return buflisted(a:buffer) && !ignored && !empty
 endfunction
 

--- a/autoload/wintabs/session.vim
+++ b/autoload/wintabs/session.vim
@@ -26,10 +26,12 @@ function! wintabs#session#save(tabpage, window, buflist)
   for buffer in a:buflist
     call add(g:Wintabs_session[a:tabpage][a:window], bufname(buffer))
   endfor
+  let g:Str_Wintabs_session = string(g:Wintabs_session)
 endfunction
 
 " load session
 function! wintabs#session#load()
+  execute 'let g:Wintabs_session = ' . g:Str_Wintabs_session
   for [tabpage, winlist] in items(g:Wintabs_session)
     " continue if tabpage no longer exists
     if tabpage > tabpagenr('$')
@@ -41,6 +43,11 @@ function! wintabs#session#load()
       if window > tabpagewinnr(tabpage, '$')
         continue
       endif
+
+	  " continue if we have no bufnamelist
+	  if len(bufnamelist) == 0
+		  continue
+	  endif
 
       " map bufnames to bufnrs
       let buflist = []

--- a/autoload/wintabs/ui.vim
+++ b/autoload/wintabs/ui.vim
@@ -43,6 +43,7 @@ function! s:get_bufline(window)
   let active_start = 0
   let active_end = 0
   let active_higroup_len = 0
+  let i = 1
 
   for buffer in getwinvar(a:window, 'wintabs_buflist')
     " get buffer name and normalize
@@ -58,7 +59,8 @@ function! s:get_bufline(window)
       let name = name.g:wintabs_ui_modified
     endif
 
-    let name = ' '.name.' '
+    let name = ' ' . i . ':' .name.' '
+    let i = i + 1
 
     " highlight current buffer
     if buffer == winbufnr(a:window)

--- a/plugin/wintabs.vim
+++ b/plugin/wintabs.vim
@@ -57,6 +57,7 @@ endfunction
 " major
 call s:set('g:wintabs_display', 'tabline')
 call s:set('g:wintabs_autoclose', 1)
+call s:set('g:wintabs_wipeout_buffer_onclose', 0)
 call s:set('g:wintabs_autoclose_vimtab', 0)
 call s:set('g:wintabs_ignored_filetypes', ['gitcommit', 'vundle', 'qf', 'vimfiler'])
 


### PR DESCRIPTION
I've added a few improvements to wintabs and also corrected a few bugs: 
# New options: `wipeout_buffers_oncloce`

If true, when closing a buffer, this will also be wiped out. The default is 0,
so the default behavior is not changes. 
# New function: `wintabs#previous`

This is changing to the last accessed tab. So, this way, you can easilly
change between the last 2 edited tabs. 
# Numbers in buffer names.

This way we can very easilly call `WintabsGo`.
# Bug fix: Saving the tabslist to session

Since, according to the VIM documentation, only string and number variables
are saved using the `globals` in the `sessionoptions`, the tabs were not
restored after a session restore. I've fixed that by adding a new variable,
`g:Str_wintabs_session`, which holds the `string` serialization of
`g:Wintabs_session`. When the session is restores, the `g:Wintabs_session`
variable is restores from the string variable.
# Bug fix: Restoring the session might on empty windows

Sometimes, an empty window gets saved in the `g:Wintabs_session` variable.
When we encounter such a variable on restore, we just ignore it. If it's in
the second window, will break the session restore, since the window is not
restored, but the `w:wintabs_buflist` variable is cleared. 
