### PR TITLE
added option to reverse order of wintabs

### DIFF
--- a/autoload/wintabs.vim
+++ b/autoload/wintabs.vim
@@ -315,7 +315,11 @@ function! wintabs#refresh_buflist(window)
   " add current buf
   let current_buffer = winbufnr(window)
   if index(buflist, current_buffer) == -1 && s:buflisted(current_buffer)
-    call add(buflist, current_buffer)
+    if (g:wintabs_reverse_order)
+      call insert(buflist, current_buffer)
+    else
+      call add(buflist, current_buffer)
+    endif
   endif
 
   " save buflist

--- a/doc/wintabs.txt
+++ b/doc/wintabs.txt
@@ -167,6 +167,12 @@ default: ['gitcommit', 'vundle', 'qf', 'vimfiler']
                 ignored by wintabs.
                 Also, |unlisted-buffer|s are ignored.
 
+*g:wintabs_reverse_order*
+values: 0 or 1
+default: 0
+                This controls whether new buffers will be added to the
+                beginning of the wintabs list rather than the end.
+
 *g:wintabs_ui_modified*
 values: string
 default: ' +'

--- a/plugin/wintabs.vim
+++ b/plugin/wintabs.vim
@@ -58,6 +58,7 @@ endfunction
 call s:set('g:wintabs_display', 'tabline')
 call s:set('g:wintabs_autoclose', 1)
 call s:set('g:wintabs_autoclose_vimtab', 0)
+call s:set('g:wintabs_reverse_order', 0)
 call s:set('g:wintabs_ignored_filetypes', ['gitcommit', 'vundle', 'qf', 'vimfiler'])
 
 " ui


### PR DESCRIPTION
I have tested that the following commands continue work as intended:
```
*:WintabsNext*
*:WintabsPrevious*
*:WintabsGo*
*:WintabsFirst*
*:WintabsLast*
*:WintabsMove*
```