### PR TITLE
Add powerline font support

### DIFF
--- a/autoload/wintabs.vim
+++ b/autoload/wintabs.vim
@@ -312,6 +312,31 @@ function! wintabs#init()
     augroup END
   endif
 
+  " if using powerline_fonts create highlight groups:
+  if g:wintabs_use_powerline
+    " get color information for seperators
+    let l:wintabs_color_active_buffer_bg = synIDattr(synIDtrans(hlID(g:wintabs_ui_active_buffer_higroup)), 'bg', "gui")
+    let l:wintabs_color_active_buffer_changed_bg = synIDattr(synIDtrans(hlID(g:wintabs_ui_active_buffer_changed_higroup)), 'bg', "gui")
+    let l:wintabs_color_inactive_buffer_bg = synIDattr(synIDtrans(hlID(g:wintabs_ui_inactive_buffer_higroup)), 'bg', "gui")
+    let l:wintabs_color_active_tab_bg = synIDattr(synIDtrans(hlID(g:wintabs_ui_active_tab_higroup)), 'bg', "gui")
+    let l:wintabs_color_inactive_tab_bg = synIDattr(synIDtrans(hlID(g:wintabs_ui_inactive_tab_higroup)), 'bg', "gui")
+    let l:wintabs_color_normal_bg = synIDattr(synIDtrans(hlID('Normal')), 'bg', "gui")
+    " create highlight groups
+    " Buffers
+    execute 'hi! WintabsPowerlineSepActiveBufferLeft cterm=NONE ctermbg=1 ctermfg=8 guibg='.l:wintabs_color_active_buffer_bg.' guifg='.l:wintabs_color_inactive_buffer_bg
+    execute 'hi! WintabsPowerlineSepActiveBufferRight cterm=NONE ctermbg=1 ctermfg=8 guibg='.l:wintabs_color_inactive_buffer_bg.' guifg='.l:wintabs_color_active_buffer_bg
+    execute 'hi! WintabsPowerlineSepActiveBufferChangedLeft cterm=NONE ctermbg=1 ctermfg=8 guibg='.l:wintabs_color_active_buffer_changed_bg.' guifg='.l:wintabs_color_inactive_buffer_bg
+    execute 'hi! WintabsPowerlineSepActiveBufferChangedRight cterm=NONE ctermbg=1 ctermfg=8 guibg='.l:wintabs_color_inactive_buffer_bg.' guifg='.l:wintabs_color_active_buffer_changed_bg
+    execute 'hi! WintabsPowerlineBufferRightmost cterm=NONE ctermbg=1 ctermfg=8 guibg='.l:wintabs_color_normal_bg.' guifg='.l:wintabs_color_inactive_buffer_bg
+    execute 'hi! WintabsPowerlineSepActiveBufferRightRightmost cterm=NONE ctermbg=1 ctermfg=8 guibg='.l:wintabs_color_normal_bg.' guifg='.l:wintabs_color_active_buffer_bg
+    execute 'hi! WintabsPowerlineSepActiveBufferChangedRightRightmost cterm=NONE ctermbg=1 ctermfg=8 guibg='.l:wintabs_color_normal_bg.' guifg='.l:wintabs_color_active_buffer_changed_bg
+    " Tabs
+    execute 'hi! WintabsPowerlineSepActiveTabLeft cterm=NONE ctermbg=1 ctermfg=8 guibg='.l:wintabs_color_inactive_tab_bg.' guifg='.l:wintabs_color_active_tab_bg
+    execute 'hi! WintabsPowerlineSepActiveTabRight cterm=NONE ctermbg=1 ctermfg=8 guibg='.l:wintabs_color_active_tab_bg.' guifg='.l:wintabs_color_inactive_tab_bg
+    execute 'hi! WintabsPowerlineTabLeftmost cterm=NONE ctermbg=1 ctermfg=8 guibg='.l:wintabs_color_normal_bg.' guifg='.l:wintabs_color_inactive_tab_bg
+    execute 'hi! WintabsPowerlineSepActiveTabLeftLeftmost cterm=NONE ctermbg=1 ctermfg=8 guibg='.l:wintabs_color_normal_bg.' guifg='.l:wintabs_color_active_tab_bg
+  endif
+
   " hijack buffer switching
   augroup wintabs_switching_buffer
     autocmd!

--- a/plugin/wintabs.vim
+++ b/plugin/wintabs.vim
@@ -74,13 +74,30 @@ call s:set('g:wintabs_ui_active_right', ' ')
 call s:set('g:wintabs_ui_show_vimtab_name', 0)
 call s:set('g:wintabs_ui_active_vimtab_left', ' ')
 call s:set('g:wintabs_ui_active_vimtab_right', ' ')
+call s:set('g:wintabs_use_powerline', '0')
+call s:set('g:wintabs_ui_powerline_sep_active_buffer_left', "\ue0b0")
+call s:set('g:wintabs_ui_powerline_sep_active_buffer_right', "\ue0b0")
+call s:set('g:wintabs_ui_powerline_sep_inbetween_buffer', "\ue0b1")
+call s:set('g:wintabs_ui_powerline_sep_rightmost_buffer', "\ue0b0")
+call s:set('g:wintabs_ui_powerline_sep_active_tab_left', "\ue0b2")
+call s:set('g:wintabs_ui_powerline_sep_active_tab_right', "\ue0b2")
+call s:set('g:wintabs_ui_powerline_sep_inbetween_tab', "\ue0b3")
+call s:set('g:wintabs_ui_powerline_sep_leftmost_tab', "\ue0b2")
 
 if g:wintabs_display == 'tabline'
-  call s:set('g:wintabs_ui_active_higroup', 'TabLineSel')
+  call s:set('g:wintabs_ui_active_buffer_higroup', 'TabLineSel')
+  call s:set('g:wintabs_ui_active_buffer_changed_higroup', g:wintabs_ui_active_buffer_higroup)
+  call s:set('g:wintabs_ui_inactive_buffer_higroup', 'Normal')
+  call s:set('g:wintabs_ui_active_tab_higroup', 'TabLineSel')
+  call s:set('g:wintabs_ui_inactive_tab_higroup', 'Normal')
 endif
 
 if g:wintabs_display == 'statusline'
-  call s:set('g:wintabs_ui_active_higroup', 'Normal')
+  call s:set('g:wintabs_ui_active_buffer_higroup', 'Normal')
+  call s:set('g:wintabs_ui_active_buffer_changed_higroup', g:wintabs_ui_active_buffer_higroup)
+  call s:set('g:wintabs_ui_inactive_buffer_higroup', 'Normal')
+  call s:set('g:wintabs_ui_active_tab_higroup', 'Normal')
+  call s:set('g:wintabs_ui_inactive_tab_higroup', 'Normal')
 endif
 
 " private


### PR DESCRIPTION
Hey there, first of all I want to say thank you very much for this awesome plugin. It is in my opinion definitely the best tabs/buffer handling plugin out there :smile:. The only feature that was missing for me personally was support for powerline font, which I have tried to add. My changes add the following variables:

1. `g:wintabs_use_powerline`
This sets whether powerline fonts are used at all, if this is set to 0 nothing changes and the plugin will behave as it always has.

2. `g:wintabs_ui_powerline_sep_active_buffer_left`
Defines the seperator symbol on the left side of the currently active buffer.

3. `g:wintabs_ui_powerline_sep_active_buffer_right`
Defines the seperator symbol on the right side of the currently active buffer.

4. `g:wintabs_ui_powerline_sep_inbetween_buffer`
Defines the seperator symbol that will be shown inbetween buffers.

5. `g:wintabs_ui_powerline_sep_rightmost_buffer`
Defines the seperator symbol that will be at the far right of the buffer list.

6. `g:wintabs_ui_powerline_sep_active_tab_left`
Defines the seperator symbol on the left of the currently active tab.

7. `g:wintabs_ui_powerline_sep_active_tab_right`
Defines the seperator symbol on the left of the currently active tab.

8. `g:wintabs_ui_powerline_sep_inbetween_tab`
Defines the seperator symbol that will be shown inbetween tabs.

9. `g:wintabs_ui_powerline_sep_leftmost_tab`
Defines the seperator symbol that will be at the far left of the tabs list.

10. `g:wintabs_ui_active_buffer_higroup`
The highlight group for the currently active buffer.
(e.g. : `g:wintabs_ui_active_buffer_higroup='WintabsActiveBuffer'` with
`hi! WintabsActiveBuffer cterm=NONE ctermbg=1 ctermfg=8 guibg=#009933 guifg=#000000`)

11. `g:wintabs_ui_active_buffer_changed_higroup`
The highlight group for the currently active buffer when there are unsaved changes.

12.`g:wintabs_ui_inactive_buffer_higroup`
The highlight group for currently inactive buffers.
(e.g. `g:wintabs_ui_inactive_buffer_higroup='WintabsInactiveBuffer'` with
`let s:linenr_bg_color = synIDattr(synIDtrans(hlID('LineNr')), 'bg', "gui")`
`let s:linenr_fg_color = synIDattr(synIDtrans(hlID('LineNr')), 'fg', "gui")`
`execute 'hi! WintabsInactiveBuffer cterm=NONE ctermbg=1 ctermfg=8 guibg='.s:linenr_bg_color.' guifg='.s:linenr_fg_color`


Here is my current setup:
`let g:wintabs_use_powerline = 1`
`let g:wintabs_ui_powerline_sep_active_buffer_left = "\ue0b4"`
`let g:wintabs_ui_powerline_sep_active_buffer_right = "\ue0b4"`
`let g:wintabs_ui_powerline_sep_inbetween_buffer = "\ue0b5"`
`let g:wintabs_ui_powerline_sep_rightmost_buffer = "\ue0b4"`
`let g:wintabs_ui_active_buffer_higroup = "WintabsActiveBuffer"`
`let g:wintabs_ui_active_buffer_changed_higroup = "WintabsActiveBufferChanged"`
`let g:wintabs_ui_inactive_buffer_higroup = "WintabsInactiveBuffer"`
`let g:wintabs_ui_active_tab_higroup = "WintabsActiveTab"`
`let g:wintabs_ui_inactive_tab_higroup = "WintabsInactiveTab"`
`let g:wintabs_ui_show_vimtab_name = 2`
`colorscheme solarized` (its important that the higroups are declared after this)
`let s:linenr_bg_color = synIDattr(synIDtrans(hlID('LineNr')), 'bg', "gui")`
`let s:linenr_fg_color = synIDattr(synIDtrans(hlID('LineNr')), 'fg', "gui")`
`execute 'hi! WintabsInactiveBuffer cterm=NONE ctermbg=1 ctermfg=8 guibg='.s:linenr_bg_color.' guifg='.s:linenr_fg_color`
`hi! WintabsActiveBuffer cterm=NONE ctermbg=1 ctermfg=8 guibg=#009933 guifg=#000000`
`hi! WintabsActiveBufferChanged cterm=NONE ctermbg=1 ctermfg=8 guibg=#f2b81e guifg=#000000`
`hi! WintabsActiveTab cterm=NONE ctermbg=1 ctermfg=8 guibg=#FFFFFF guifg=#000000`
`hi! WintabsInactiveTab cterm=NONE ctermbg=1 ctermfg=8 guibg=#073642 guifg=#586e75`

Which ends up to look like this for an unmodified buffer:
![screenshot from 2017-09-25 21 51 00](https://user-images.githubusercontent.com/12450485/30812470-5f74de98-a23d-11e7-950a-b7b4c6f28888.png)

And this for a modified buffer:
![screenshot from 2017-09-25 21 53 49](https://user-images.githubusercontent.com/12450485/30812481-673d0d58-a23d-11e7-9d9e-7f7aad74a385.png)

A different possible look:
![screenshot from 2017-09-26 10 42 32](https://user-images.githubusercontent.com/12450485/30840041-a8bdfcb4-a2a7-11e7-9ddb-719de95c99f6.png)



There are a couple of problems still:
1. The seperators break when .vimrc is reloaded from within vim, a restart fixes this, but this should definitly be fixed
2. I haven't been able to get the truncation of the bufferline to work yet
3. Doesn't work with the 'taboo' plugin
4. Haven't implemented it for statusline option yet

I guess its not really in a mergable state right now but if you are interested in this feature I would try to fix the problems that still exist and add my changes to the docs. Just let me know what you think. 