### PR TITLE
Fixes status bar highlighting in statusline mode

### DIFF
--- a/autoload/wintabs/renderers.vim
+++ b/autoload/wintabs/renderers.vim
@@ -14,7 +14,7 @@ endfunction
 function! wintabs#renderers#buffer(bufnr, config)
   return {
         \'label': wintabs#renderers#buf_label(a:bufnr),
-        \'highlight': a:config.is_active ? g:wintabs_ui_active_higroup : '',
+        \'highlight': a:config.is_active ? g:wintabs_ui_active_higroup : g:wintabs_ui_inactive_higroup,
         \}
 endfunction
 
@@ -34,7 +34,7 @@ function! wintabs#renderers#buffer_sep(config)
   endif
   return {
         \'label': label,
-        \'highlight': a:config.is_active ? g:wintabs_ui_active_higroup : '',
+        \'highlight': a:config.is_active ? g:wintabs_ui_active_higroup : g:wintabs_ui_inactive_higroup,
         \}
 endfunction
 
@@ -45,7 +45,7 @@ function! wintabs#renderers#tab(tabnr, config)
   endif
   return {
         \'label': label,
-        \'highlight': a:config.is_active ? g:wintabs_ui_active_higroup : '',
+        \'highlight': a:config.is_active ? g:wintabs_ui_active_higroup : g:wintabs_ui_inactive_higroup,
         \}
 endfunction
 
@@ -59,7 +59,7 @@ function! wintabs#renderers#tab_sep(config)
   endif
   return {
         \'label': label,
-        \'highlight': a:config.is_active ? g:wintabs_ui_active_higroup : '',
+        \'highlight': a:config.is_active ? g:wintabs_ui_active_higroup : g:wintabs_ui_inactive_higroup,
         \}
 endfunction
 
@@ -67,7 +67,7 @@ function! wintabs#renderers#left_arrow()
   return {
         \'type': 'left_arrow',
         \'label': g:wintabs_ui_arrow_left,
-        \'highlight': '',
+        \'highlight': g:wintabs_ui_inactive_higroup,
         \}
 endfunction
 
@@ -75,7 +75,7 @@ function! wintabs#renderers#right_arrow()
   return {
         \'type': 'right_arrow',
         \'label': g:wintabs_ui_arrow_right,
-        \'highlight': '',
+        \'highlight': g:wintabs_ui_inactive_higroup,
         \}
 endfunction
 
@@ -83,7 +83,7 @@ function! wintabs#renderers#line_sep()
   return {
         \'type': 'sep',
         \'label': g:wintabs_ui_sep_spaceline,
-        \'highlight': '',
+        \'highlight': g:wintabs_ui_inactive_higroup,
         \}
 endfunction
 
@@ -91,7 +91,7 @@ function! wintabs#renderers#padding(len)
   return {
         \'type': 'sep',
         \'label': repeat(' ', a:len),
-        \'highlight': '',
+        \'highlight': g:wintabs_ui_inactive_higroup,
         \}
 endfunction
 


### PR DESCRIPTION
Added a `g:wintabs_ui_inactive_higroup` property which fixes the problem of no highlighting being set on the inactive buffer elements.

Before:
![screenshot from 2018-05-20 19-46-23](https://user-images.githubusercontent.com/550409/40284512-a00827ce-5c66-11e8-94be-2a57e75b5b53.png)

After:
![screenshot from 2018-05-20 19-48-53](https://user-images.githubusercontent.com/550409/40284533-d6f1f486-5c66-11e8-886d-213d1518fa09.png)