### PR TITLE
show the index (starting from 1) of the buffer

### DIFF
--- a/autoload/wintabs/renderers.vim
+++ b/autoload/wintabs/renderers.vim
@@ -114,11 +114,12 @@ function! wintabs#renderers#bufname(bufnr)
 endfunction
 
 function! wintabs#renderers#buf_label(bufnr)
-  let label = g:wintabs_ui_buffer_name_format
-  let label = substitute(label, "%t", wintabs#renderers#bufname(a:bufnr), "g")
-  let label = substitute(label, "%n", a:bufnr, "g")
-  return label
+    let label = g:wintabs_ui_buffer_name_format
+    let label = substitute(label, "%t", wintabs#renderers#bufname(a:bufnr), "g")
+    let label = substitute(label, "%n", index(w:wintabs_buflist, a:bufnr) + 1, "g")
+    return label
 endfunction
+
 
 function! wintabs#renderers#tab_label(tabnr)
   let label = ''


### PR DESCRIPTION
show the index of the buffer (starting with 1) in the wintabs buflist instead of the buffer number in vim. This can be used to easily identify the tab number and jump to it using a mapping, for example "\<leader\>{index}"