### PR TITLE
fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ optional, used for Powerline style rendering.
 
 [vim-plug](https://github.com/junegunn/vim-plug)
 
-    plug 'zefei/vim-wintabs'
-    plug 'zefei/vim-wintabs-powerline'
+    Plug 'zefei/vim-wintabs'
+    Plug 'zefei/vim-wintabs-powerline'
 
 # Usage
 


### PR DESCRIPTION
Fixes two typos in README.md (vim-plug provides `Plug` command, not `plug` command)