### PR TITLE
Capitalise `Plugin` for Vundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ optional, used for Powerline style rendering.
 
 [vundle](https://github.com/vundlevim/vundle.vim)
 
-    plugin 'zefei/vim-wintabs'
-    plugin 'zefei/vim-wintabs-powerline'
+    Plugin 'zefei/vim-wintabs'
+    Plugin 'zefei/vim-wintabs-powerline'
 
 [vim-plug](https://github.com/junegunn/vim-plug)
 


### PR DESCRIPTION
Vundle requires `Plugin`, but doesn't accept `plugin`. This change makes copy and pasting the 2 commands from the github `README` page into `.vimrc` easier.